### PR TITLE
[refactor-fix-datapoint] refactor to fixed bug

### DIFF
--- a/src/main/java/entities/DataPoint.java
+++ b/src/main/java/entities/DataPoint.java
@@ -20,7 +20,7 @@ public class DataPoint {
      *
      */
     public DataPoint(int month, int day, int year) {
-        date = new Date(convertEpochSeconds(month, day, year));
+        date = new Date(convertEpochMilliseconds(month, day, year));
     }
 
     /**
@@ -31,9 +31,9 @@ public class DataPoint {
      * @param year The year of calendar date - greater than or equal to 1
      * @return epochSeconds number of seconds from Epoch
      */
-    public static long convertEpochSeconds(int month, int day, int year) {
+    public static long convertEpochMilliseconds(int month, int day, int year) {
         LocalDateTime time = LocalDateTime.of(year, month, day, 0, 0);
-        return time.toEpochSecond(ZoneOffset.UTC);
+        return time.toEpochSecond(ZoneOffset.UTC) * 1000;
     }
 
     /**

--- a/src/main/java/entities/DataPoint.java
+++ b/src/main/java/entities/DataPoint.java
@@ -21,6 +21,7 @@ public class DataPoint {
      */
     public DataPoint(int month, int day, int year) {
         date = new Date(convertEpochMilliseconds(month, day, year));
+        exerciseList = new ArrayList<Exercise>();
     }
 
     /**

--- a/src/main/java/use_cases/DataPointMap.java
+++ b/src/main/java/use_cases/DataPointMap.java
@@ -8,7 +8,14 @@ import java.util.HashMap;
  * DataPointMap use case - Mapping of Date objects to DataPoint objects
  */
 public class DataPointMap {
-    private HashMap<Date, DataPoint> dataPointMap = new HashMap<Date, DataPoint>();
+    private HashMap<Date, DataPoint> dataPointMap;
+
+    /**
+     * creates a new DataPointMap object
+     */
+    public DataPointMap() {
+        dataPointMap = new HashMap<Date, DataPoint>();
+    }
 
     /**
      * Gets the dataPointMap

--- a/src/test/java/display_zoom/DataPointMapTest.java
+++ b/src/test/java/display_zoom/DataPointMapTest.java
@@ -28,7 +28,7 @@ public class DataPointMapTest {
         dp2 = new DataPoint(11, 11, 2022);
         dp3 = new DataPoint(11, 12, 2022);
 
-        long seconds1 = DataPoint.convertEpochSeconds(11, 10, 2022);
+        long seconds1 = DataPoint.convertEpochMilliseconds(11, 10, 2022);
         date = new Date(seconds1);
 
         mapToMerge.put(dp2.getDate(), dp2);

--- a/src/test/java/display_zoom/DataPointTest.java
+++ b/src/test/java/display_zoom/DataPointTest.java
@@ -28,7 +28,6 @@ public class DataPointTest {
         exercise3 = new Exercise("jumping", 10);
         exercises.add(exercise1);
         exercises.add(exercise3);
-
     }
 
     @After
@@ -37,14 +36,14 @@ public class DataPointTest {
 
     @Test(timeout = 50)
     public void testConvertEpochSecondsBeginning() {
-        long actual = DataPoint.convertEpochSeconds(1, 1, 1970);
+        long actual = DataPoint.convertEpochMilliseconds(1, 1, 1970);
         long expected = 0;
         assertEquals(actual, expected);
     }
 
     @Test(timeout = 50)
-    public void testConvertEpochSecondsLaterDate() {
-        long actual = DataPoint.convertEpochSeconds(11, 21, 2022);
+    public void testConvertEpochMillisecondsLaterDate() {
+        long actual = DataPoint.convertEpochMilliseconds(11, 21, 2022);
         long expected = 1669006800;
         assertEquals(actual, expected);
     }


### PR DESCRIPTION
Fixed bug in the `DataPoint.convertEpochMilliseconds()` method. There was an issue with the calculation for Epoch time conversion. I changed the method from `convertEpochSeconds()` to `convertEpochMilliseconds()` to support passing in a value in milliseconds instead of seconds to the Java `Date` constructor.  