### PR TITLE
[refactor-fix-displayview-jswing] fixed errors of relating to displayview and jswing

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
@@ -6,13 +5,4 @@
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="corretto-11" project-jdk-type="JavaSDK" />
-=======
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="FrameworkDetectionExcludesConfiguration">
-    <file type="web" url="file://$PROJECT_DIR$" />
-  </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="corretto-11" project-jdk-type="JavaSDK" />
->>>>>>> ad8021f789e2906a97891c82d3452c528bf6563b
 </project>

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -10,7 +10,6 @@ public class Main {
         CardLayout cardLayout = new CardLayout();
         JPanel screens = new JPanel(cardLayout);
         application.add(screens);
-
         DashboardScreen dashboardScreen = new DashboardScreen();
         screens.add(dashboardScreen);
         cardLayout.show(screens, "dashboard");

--- a/src/main/java/screens/DashboardScreen.java
+++ b/src/main/java/screens/DashboardScreen.java
@@ -44,7 +44,7 @@ public class DashboardScreen extends JPanel implements ActionListener {
         // Creating the buttons for actions
         JButton logOut = new JButton(logOutText);
         JButton back = new JButton(backText);
-
+        
         JPanel buttons = new JPanel();
         buttons.add(back);
         buttons.add(logOut);

--- a/src/main/java/screens/Table.java
+++ b/src/main/java/screens/Table.java
@@ -16,6 +16,11 @@ public class Table implements VisualUnit {
      * @return 2D array to be displayed on UI
      */
     public static Object[][] generate(DataPointMap data) {
+        // error handling for the event that a user finds an exploit to get to this screen without logging in
+        if (data == null) {
+            return new Object[0][3];
+        }
+
         Object[][] tableFormat = new Object[data.getData().keySet().size()][3];
 
 //        information: the table headers are the following: {


### PR DESCRIPTION
This feature is a fix to the issue of JSwing erroring out when Main.java was run to display the Dashboard UI.

Notes about the pull request:
- There was a merge conflict that we did not correctly resolve. This has now been solved in `.idea/misc.xml`. The issue was that when we were solving this merge conflict, we did not change the file, so it left two versions of `.idea/misc.xml` in its file.
- In `src/main/java/screens/Table.java`, within the `Table.generate(DataPointMap data)` method, we did not consider what would happen in the case that there is no logged-in user. The way that `Table.generate` is called is within `src/main/java/screens/DashboardScreen`, which calls `Table.generate` based on what user is logged in.